### PR TITLE
Implement resizing capabilities in NodeGroup and RendererCanvasGroup

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flowscape-ui/core-sdk",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Engine for building infinite canvas editors, design tools, and visual builders. Framework-agnostic, TypeScript, Konva.",
   "keywords": [
     "flowscape",

--- a/playground/src/main.ts
+++ b/playground/src/main.ts
@@ -26,6 +26,7 @@ import {
   TextAlign,
   TextWrapMode,
   TextVerticalAlign,
+  NodeGroup,
 } from '../../src/nodes';
 
 import { CanvasRendererHost } from '../../src/renderer/hosts';
@@ -118,9 +119,11 @@ layerBackground.setImageOffsetX("50%");
 layerBackground.setImageOffsetY("50%");
 layerBackground.setImagePosition("50%", "50%");
 
+const groupNode = new NodeGroup(1000);
+
 const rectNode = new NodeRect(1);
 rectNode.setPosition(120, 110);
-rectNode.setSize(180, 120);
+rectNode.setSize(580, 520);
 rectNode.setCornerRadius({
   tl: 28,
   tr: 28,
@@ -128,12 +131,12 @@ rectNode.setCornerRadius({
   br: 0
 });
 rectNode.setFill("#D1D5DB");
-rectNode.setStrokeFill("#0F172A");
+rectNode.setStrokeFill("red");
 rectNode.setStrokeWidth({ t: 3, r: 3, b: 3, l: 3 });
-rectNode.setRotation(-8);
+// rectNode.setRotation(-8);
 
 const rectNode2 = new NodeRect(20);
-rectNode2.setPosition(0, 0);
+rectNode2.setPosition(-100, 0);
 rectNode2.setSize(180, 120);
 rectNode2.setCornerRadius({
   tl: 28,
@@ -142,9 +145,9 @@ rectNode2.setCornerRadius({
   br: 0
 });
 rectNode2.setFill("#D1D5DB");
-rectNode2.setStrokeFill("#0F172A");
+rectNode2.setStrokeFill("red");
 rectNode2.setStrokeWidth({ t: 3, r: 3, b: 3, l: 3 });
-rectNode2.setRotation(-8);
+// rectNode2.setRotation(-8);
 
 const ellipseNode = new NodeEllipse(2);
 ellipseNode.setPosition(370, 120);
@@ -219,11 +222,16 @@ textNode.setText(
   "interactive scene systems."
 );
 
+groupNode.addChild(rectNode);
+groupNode.addChild(rectNode2);
+layerWorld.addNode(groupNode);
+
+
 layerWorld.addNode(textNode);
 layerWorld.addNode(lineNode);
 layerWorld.addNode(polygonNode);
-layerWorld.addNode(rectNode2);
-layerWorld.addNode(rectNode);
+// layerWorld.addNode(rectNode2);
+// layerWorld.addNode(rectNode);
 layerWorld.addNode(ellipseNode);
 layerWorld.addNode(starNode);
 layerWorld.addNode(pathNode);

--- a/src/core/transform/Transform.ts
+++ b/src/core/transform/Transform.ts
@@ -193,9 +193,14 @@ export class Transform implements ITransform {
   /*****************************************************************/
   /*                         Local Matrix                          */
   /*****************************************************************/
-  public getLocalMatrix(width: number, height: number): Matrix {
-    const px = MathF32.mul(width, this._pivot.x);
-    const py = MathF32.mul(height, this._pivot.y);
+  public getLocalMatrix(
+    width: number,
+    height: number,
+    boundsX: number = 0,
+    boundsY: number = 0
+  ): Matrix {
+    const px = MathF32.add(boundsX, MathF32.mul(width, this._pivot.x));
+    const py = MathF32.add(boundsY, MathF32.mul(height, this._pivot.y));
     return this._composeMatrix(
       this._position,
       this._scale,

--- a/src/core/transform/types/ITransform.ts
+++ b/src/core/transform/types/ITransform.ts
@@ -227,5 +227,5 @@ export interface ITransform {
      *
      * Итоговая матрица используется при отрисовке объекта.
      */
-    getLocalMatrix(width: number, height: number): Matrix;
+    getLocalMatrix(width: number, height: number, boundsX?: number, boundsY?: number): Matrix;
 }

--- a/src/nodes/base/NodeBase.ts
+++ b/src/nodes/base/NodeBase.ts
@@ -195,8 +195,8 @@ export class NodeBase implements INode {
 
     public getSize(): Size {
         return {
-            width: this._width,
-            height: this._height,
+            width: this.getWidth(),
+            height: this.getHeight(),
         }
     }
 
@@ -569,7 +569,13 @@ export class NodeBase implements INode {
     }
 
     public getLocalMatrix(): Matrix {
-        return this._transform.getLocalMatrix(this._width, this._height);
+        const local = this.getLocalOBB();
+        return this._transform.getLocalMatrix(
+            local.width,
+            local.height,
+            local.x,
+            local.y,
+        );
     }
 
     public getWorldMatrix(): Matrix {
@@ -779,12 +785,13 @@ export class NodeBase implements INode {
 
             // 2) Translating the world point into the node's local space
             const localPoint = this._applyMatrixToPoint(invMatrix, worldPoint);
+            const localBounds = this.getLocalOBB();
 
-            // 3) Now the check is elementary: the point must be inside [0, 0, width, height]
-            return localPoint.x >= 0 &&
-                localPoint.x <= this._width &&
-                localPoint.y >= 0 &&
-                localPoint.y <= this._height;
+            // 3) Check against local OBB bounds.
+            return localPoint.x >= localBounds.x &&
+                localPoint.x <= localBounds.x + localBounds.width &&
+                localPoint.y >= localBounds.y &&
+                localPoint.y <= localBounds.y + localBounds.height;
         } catch (e) {
             // If the matrix is not invertible (for example, scale = 0), you cannot enter the node// Если матрица не инвертируема (например, scale = 0), попасть в ноду нельзя
             return false;
@@ -901,8 +908,8 @@ export class NodeBase implements INode {
             x: position.x,
             y: position.y,
 
-            width: this._width,
-            height: this._height,
+            width: this.getWidth(),
+            height: this.getHeight(),
 
             rotation: this.getRotation(),
 

--- a/src/nodes/group/NodeGroup.ts
+++ b/src/nodes/group/NodeGroup.ts
@@ -1,9 +1,402 @@
-import type { ID } from "../../core/types";
-import { NodeBase, NodeType } from "../base";
-import type { INodeGroup } from "./types";
+import {
+    type Vector2,
+    type ID,
+    MathF32,
+} from "../../core";
+import {
+    type Rect,
+    NodeBase,
+    NodeType,
+} from "../base";
+import { ShapeBase } from "../shape";
+import {
+    type INodeGroup,
+    GroupChildrenResizeMode,
+} from "./types";
 
-export class NodeGroup extends NodeBase implements INodeGroup {
+const GROUP_EPSILON = 1e-6;
+
+type GroupChildResizeSnapshot = {
+    id: ID;
+    position: Vector2;
+    scaleX: number;
+    scaleY: number;
+    rotation: number;
+};
+
+export type GroupResizeSnapshot = {
+    bounds: Rect;
+    children: Map<ID, GroupChildResizeSnapshot>;
+};
+
+export class NodeGroup extends ShapeBase implements INodeGroup {
+    private _activeResizeSnapshot: GroupResizeSnapshot | null = null;
+    private _collapsedBoundsOverride: Rect | null = null;
+
     constructor(id: ID, name?: string) {
         super(id, NodeType.Group, name ?? "Group");
+    }
+
+    public override hitTest(worldPoint: Vector2): boolean {
+        const bounds = this.getWorldAABB();
+
+        if (
+            worldPoint.x < bounds.x ||
+            worldPoint.x > bounds.x + bounds.width ||
+            worldPoint.y < bounds.y ||
+            worldPoint.y > bounds.y + bounds.height
+        ) {
+            return false;
+        }
+
+        const children = this.getChildren();
+
+        if (children.length === 0) {
+            return false;
+        }
+
+        for (let i = children.length - 1; i >= 0; i -= 1) {
+            const child = children[i]!;
+
+            if (!child.isVisible()) {
+                continue;
+            }
+
+            if (child.hitTest(worldPoint)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public override setWidth(value: number): void {
+        if (this.isLockedInHierarchy()) {
+            return;
+        }
+
+        const bounds = this._getChildrenLocalOBB();
+
+        if (!bounds) {
+            super.setWidth(MathF32.max(0, value));
+            return;
+        }
+
+        this._resizeToBounds({
+            x: bounds.x,
+            y: bounds.y,
+            width: MathF32.max(0, value),
+            height: bounds.height,
+        });
+    }
+
+    public override setHeight(value: number): void {
+        if (this.isLockedInHierarchy()) {
+            return;
+        }
+
+        const bounds = this._getChildrenLocalOBB();
+
+        if (!bounds) {
+            super.setHeight(MathF32.max(0, value));
+            return;
+        }
+
+        this._resizeToBounds({
+            x: bounds.x,
+            y: bounds.y,
+            width: bounds.width,
+            height: MathF32.max(0, value),
+        });
+    }
+
+    public override setSize(width: number, height: number): void {
+        if (this.isLockedInHierarchy()) {
+            return;
+        }
+
+        const bounds = this._getChildrenLocalOBB();
+
+        if (!bounds) {
+            super.setSize(MathF32.max(0, width), MathF32.max(0, height));
+            return;
+        }
+
+        this._resizeToBounds({
+            x: bounds.x,
+            y: bounds.y,
+            width: MathF32.max(0, width),
+            height: MathF32.max(0, height),
+        });
+    }
+
+    public resizeChildrenBySize(width: number, height: number): void {
+        this.setSize(width, height);
+    }
+
+    public resizeChildrenByScale(width: number, height: number): void {
+        this.setSize(width, height);
+    }
+
+    public beginResizeSession(): void {
+        if (this.isLockedInHierarchy()) {
+            return;
+        }
+
+        this._activeResizeSnapshot = this._createResizeSnapshot();
+    }
+
+    public createResizeSnapshot(): GroupResizeSnapshot | null {
+        return this._createResizeSnapshot();
+    }
+
+    public endResizeSession(): void {
+        this._activeResizeSnapshot = null;
+        this._collapsedBoundsOverride = null;
+    }
+
+    public hasActiveResizeSession(): boolean {
+        return this._activeResizeSnapshot !== null;
+    }
+
+    public override getWidth(): number {
+        return this.getLocalOBB().width;
+    }
+
+    public override getHeight(): number {
+        return this.getLocalOBB().height;
+    }
+
+    public override getLocalOBB(): Rect {
+        if (this._collapsedBoundsOverride) {
+            return this._collapsedBoundsOverride;
+        }
+
+        const childrenBounds = this._getChildrenLocalOBB();
+
+        if (!childrenBounds) {
+            return super.getLocalOBB();
+        }
+
+        return childrenBounds;
+    }
+
+    private _resizeToBounds(targetBounds: Rect): void {
+        const snapshot = this._activeResizeSnapshot ?? this._createResizeSnapshot();
+
+        if (!snapshot) {
+            return;
+        }
+
+        this._applyResizeFromSnapshot(snapshot, targetBounds, GroupChildrenResizeMode.Scale);
+    }
+
+    public applyResizeFromSnapshot(
+        snapshot: GroupResizeSnapshot,
+        targetBounds: Rect,
+    ): void {
+        this._applyResizeFromSnapshot(snapshot, targetBounds, GroupChildrenResizeMode.Scale);
+    }
+
+    private _createResizeSnapshot(): GroupResizeSnapshot | null {
+        const bounds = this._getChildrenLocalOBB();
+
+        if (!bounds) {
+            return null;
+        }
+
+        const children = new Map<ID, GroupChildResizeSnapshot>();
+
+        for (const child of this.getChildren()) {
+            children.set(child.id, {
+                id: child.id,
+                position: child.getPosition(),
+                scaleX: child.getScaleX(),
+                scaleY: child.getScaleY(),
+                rotation: child.getRotation(),
+            });
+        }
+
+        return {
+            bounds,
+            children,
+        };
+    }
+
+    private _applyResizeFromSnapshot(
+        snapshot: GroupResizeSnapshot,
+        targetBounds: Rect,
+        mode: GroupChildrenResizeMode,
+    ): void {
+        const children = this.getChildren();
+
+        if (children.length === 0) {
+            return;
+        }
+
+        const sourceBounds = snapshot.bounds;
+
+        const sourceWidth = sourceBounds.width;
+        const sourceHeight = sourceBounds.height;
+
+        const nextWidth = MathF32.max(0, targetBounds.width);
+        const nextHeight = MathF32.max(0, targetBounds.height);
+
+        const collapseX = nextWidth <= GROUP_EPSILON;
+        const collapseY = nextHeight <= GROUP_EPSILON;
+
+        const scaleX = sourceWidth <= GROUP_EPSILON
+            ? 0
+            : MathF32.toF32(nextWidth / sourceWidth);
+
+        const scaleY = sourceHeight <= GROUP_EPSILON
+            ? 0
+            : MathF32.toF32(nextHeight / sourceHeight);
+
+        const sourceX = sourceBounds.x;
+        const sourceY = sourceBounds.y;
+
+        const targetX = targetBounds.x;
+        const targetY = targetBounds.y;
+
+        this._collapsedBoundsOverride =
+            collapseX || collapseY
+                ? {
+                    x: targetX,
+                    y: targetY,
+                    width: nextWidth,
+                    height: nextHeight,
+                }
+                : null;
+
+        for (const child of children) {
+            const childSnapshot = snapshot.children.get(child.id);
+
+            if (!childSnapshot) {
+                continue;
+            }
+
+            const rotated = this._isNodeRotatedInGroupAxes(childSnapshot.rotation);
+            const sourcePosition = childSnapshot.position;
+
+            let nextPositionX = MathF32.add(
+                targetX,
+                MathF32.mul(
+                    MathF32.sub(sourcePosition.x, sourceX),
+                    scaleX,
+                ),
+            );
+
+            let nextPositionY = MathF32.add(
+                targetY,
+                MathF32.mul(
+                    MathF32.sub(sourcePosition.y, sourceY),
+                    scaleY,
+                ),
+            );
+
+            let nextScaleX = MathF32.mul(childSnapshot.scaleX, scaleX);
+            let nextScaleY = MathF32.mul(childSnapshot.scaleY, scaleY);
+
+            if (collapseX) {
+                nextPositionX = targetX;
+                nextScaleX = 0;
+
+                // Для rotated child одной нулевой оси недостаточно:
+                // его вторая ось всё ещё даёт проекцию на X.
+                if (rotated && !collapseY) {
+                    nextPositionY = targetY;
+                    nextScaleY = 0;
+                }
+            }
+
+            if (collapseY) {
+                nextPositionY = targetY;
+                nextScaleY = 0;
+
+                // Аналогично для коллапса по Y.
+                if (rotated && !collapseX) {
+                    nextPositionX = targetX;
+                    nextScaleX = 0;
+                }
+            }
+
+            child.setPosition(nextPositionX, nextPositionY);
+
+            if (mode === GroupChildrenResizeMode.Size) {
+                const nextWidthValue = MathF32.max(
+                    0,
+                    MathF32.mul(child.getWidth(), scaleX),
+                );
+                const nextHeightValue = MathF32.max(
+                    0,
+                    MathF32.mul(child.getHeight(), scaleY),
+                );
+
+                child.setSize(nextWidthValue, nextHeightValue);
+                continue;
+            }
+
+            child.setScale(nextScaleX, nextScaleY);
+        }
+
+        if (!collapseX && !collapseY) {
+            this._collapsedBoundsOverride = null;
+        }
+    }
+
+    private _isNodeRotatedInGroupAxes(rotationDeg: number): boolean {
+        const rotationRad = MathF32.degToRad(rotationDeg);
+        return !MathF32.nearlyEqual(MathF32.sin(rotationRad), 0);
+    }
+
+    private _getChildrenLocalOBB(): Rect | null {
+        const children = this.getChildren();
+
+        if (children.length === 0) {
+            return null;
+        }
+
+        let minX = Infinity;
+        let minY = Infinity;
+        let maxX = -Infinity;
+        let maxY = -Infinity;
+
+        for (const child of children) {
+            const childBounds = child.getHierarchyLocalOBB();
+            const childMatrix = (child as NodeBase).getLocalMatrix();
+
+            const corners: [Vector2, Vector2, Vector2, Vector2] = [
+                { x: childBounds.x, y: childBounds.y },
+                { x: childBounds.x + childBounds.width, y: childBounds.y },
+                { x: childBounds.x + childBounds.width, y: childBounds.y + childBounds.height },
+                { x: childBounds.x, y: childBounds.y + childBounds.height },
+            ];
+
+            for (const corner of corners) {
+                const point = this._applyMatrixToPoint(childMatrix, corner);
+
+                if (point.x < minX) minX = point.x;
+                if (point.y < minY) minY = point.y;
+                if (point.x > maxX) maxX = point.x;
+                if (point.y > maxY) maxY = point.y;
+            }
+        }
+
+        if (
+            !Number.isFinite(minX) ||
+            !Number.isFinite(minY) ||
+            !Number.isFinite(maxX) ||
+            !Number.isFinite(maxY)
+        ) {
+            return null;
+        }
+
+        return {
+            x: MathF32.toF32(minX),
+            y: MathF32.toF32(minY),
+            width: MathF32.sub(maxX, minX),
+            height: MathF32.sub(maxY, minY),
+        };
     }
 }

--- a/src/nodes/group/types.ts
+++ b/src/nodes/group/types.ts
@@ -1,3 +1,11 @@
-import type { INode } from "../base";
+import type { IShapeBase } from "../shape";
 
-export interface INodeGroup extends INode {}
+export enum GroupChildrenResizeMode {
+    Size = "size",
+    Scale = "scale",
+}
+
+export interface INodeGroup extends IShapeBase {
+    resizeChildrenBySize(width: number, height: number): void;
+    resizeChildrenByScale(width: number, height: number): void;
+}

--- a/src/renderer/canvas/nodes/group/RendererCanvasGroup.ts
+++ b/src/renderer/canvas/nodes/group/RendererCanvasGroup.ts
@@ -1,0 +1,13 @@
+import Konva from "konva";
+import type { INodeGroup } from "../../../../nodes";
+import { RendererCanvasBase } from "../base";
+
+export class RendererCanvasGroup extends RendererCanvasBase<INodeGroup> {
+    public create(node: INodeGroup): Konva.Group {
+        return new Konva.Group({
+            id: String(node.id),
+        });
+    }
+
+    protected onUpdate(_node: INodeGroup, _view: Konva.Group): void {}
+}

--- a/src/renderer/canvas/nodes/group/index.ts
+++ b/src/renderer/canvas/nodes/group/index.ts
@@ -1,0 +1,1 @@
+export * from "./RendererCanvasGroup";

--- a/src/renderer/canvas/nodes/index.ts
+++ b/src/renderer/canvas/nodes/index.ts
@@ -1,4 +1,5 @@
 export * from "./base";
+export * from "./group";
 export * from "./rect";
 export * from "./ellipse";
 export * from "./polygon";

--- a/src/renderer/canvas/scene/layers/world/RendererLayerWorldCanvas.ts
+++ b/src/renderer/canvas/scene/layers/world/RendererLayerWorldCanvas.ts
@@ -1,6 +1,6 @@
 import Konva from "konva";
 import type { IRendererLayerWorld } from "./types";
-import { RendererCanvasEllipse, RendererCanvasImage, RendererCanvasLine, RendererCanvasManager, RendererCanvasPath, RendererCanvasPolygon, RendererCanvasRect, RendererCanvasRegistry, RendererCanvasStar, RendererCanvasText, RendererCanvasVideo } from "../../../nodes";
+import { RendererCanvasEllipse, RendererCanvasGroup, RendererCanvasImage, RendererCanvasLine, RendererCanvasManager, RendererCanvasPath, RendererCanvasPolygon, RendererCanvasRect, RendererCanvasRegistry, RendererCanvasStar, RendererCanvasText, RendererCanvasVideo } from "../../../nodes";
 import { NodeType } from "../../../../../nodes";
 import type { CameraState } from "../../../../../core/camera";
 import { GridRenderer, KonvaGridView } from "../../../../../grid";
@@ -125,6 +125,7 @@ export class RendererLayerWorldCanvas implements IRendererLayerWorld {
 
 
     private _registerDefaultRenderers(): void {
+        this._registry.register(NodeType.Group, new RendererCanvasGroup());
         this._registry.register(NodeType.Rect, new RendererCanvasRect());
         this._registry.register(NodeType.Ellipse, new RendererCanvasEllipse());
         this._registry.register(NodeType.Polygon, new RendererCanvasPolygon());


### PR DESCRIPTION
## What's improved

- Groups now use content-based hit testing instead of full bounds hit detection
- Improved general selection UX for grouped elements
- Stabilized current resize behavior for production use

## Known limitations

Advanced rotated-child resize edge cases are deferred for a future transform-system refactor.